### PR TITLE
A few small updates from my experience on CentOS and Debian machines

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 nvm_install_script_version: "0.33.11"
 nvm_user_name: "root"
 nvm_dir: "/var/lib/nvm"  # for global installation
+nvm_link_global: "yes"
 nvm_node_version: "8.11.3"
 nvm_install_globally: []     # libraries to add globally
 # nvm_dir: "~"           # for user installation -> isn't working yet however

--- a/tasks/_symlink.yml
+++ b/tasks/_symlink.yml
@@ -15,3 +15,4 @@
     state: link
     mode: "u+rwx,g+rx,o+rx"
   loop: "{{ find_result.files }}"
+  when: nvm_link_global == "yes"

--- a/tasks/_symlink.yml
+++ b/tasks/_symlink.yml
@@ -8,6 +8,13 @@
     file_type: any
   register: find_result
 
+- name: Remove original global packages before symlink
+  file:
+    path: "/usr/bin/{{ item.path | basename }}"
+    state: absent
+  loop: "{{ find_result.files }}"
+  when: nvm_link_global == "yes"
+
 - name: Symlink global packages into PATH for specific environments (like cron's) to be able to access them.
   file:
     src: "{{ item.path }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
-- include: setup-Redhat.yml
+- include_tasks: setup-Redhat.yml
   when: ansible_os_family == "RedHat"
 
-- include: setup-Debian.yml
+- include_tasks: setup-Debian.yml
   when: ansible_os_family == "Debian"
 
   # make it so that anyone can use it!
-- name: Create the target VNM dir
+- name: Create the target NVM dir
   file: path="{{ nvm_dir }}" state=directory owner="{{ nvm_user_name }}" mode="o+rwx"
 
   # variablize the name of the installation script so it fire installation script properly when
@@ -43,10 +43,12 @@
 - name: Make the node binary always discoverable by symlinking to a system bin PATH that cron sees by default too
   file: src="{{ nvm_dir }}/versions/node/v{{ nvm_node_version }}/bin/node"
         dest="/usr/bin/node" state=link mode="u+rwx,g+rx,o+rx"
+  when: nvm_link_global == "yes"
 
 - name: Make the npm binary always discoverable by symlinking to a system bin PATH that cron sees by default too
   file: src="{{ nvm_dir }}/versions/node/v{{ nvm_node_version }}/bin/npm"
         dest="/usr/bin/npm" state=link mode="u+rwx,g+rx,o+rx"
+  when: nvm_link_global == "yes"
 
 ### ---- Install version-agnostic and version-aware version of globals ---- ###
 ### TODO: DRY it some way smart

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,9 +40,21 @@
              [ -s \"$NVM_DIR/bash_completion\" ] && \. \"$NVM_DIR/bash_completion\""
   when: ansible_os_family == "RedHat"
 
+- name: Remove original node binary before symlink
+  file:
+    path: "/usr/bin/node"
+    state: absent
+  when: nvm_link_global == "yes"
+
 - name: Make the node binary always discoverable by symlinking to a system bin PATH that cron sees by default too
   file: src="{{ nvm_dir }}/versions/node/v{{ nvm_node_version }}/bin/node"
         dest="/usr/bin/node" state=link mode="u+rwx,g+rx,o+rx"
+  when: nvm_link_global == "yes"
+
+- name: Remove original npm binary before symlink
+  file:
+    path: "/usr/bin/npm"
+    state: absent
   when: nvm_link_global == "yes"
 
 - name: Make the npm binary always discoverable by symlinking to a system bin PATH that cron sees by default too


### PR DESCRIPTION
- Replaces deprecated include with include_tasks
- Fix type-o VNM with NVM
- Adds config variable for nvm_link_global so folks can choose not to symlink the files
- Adds remove tasks to clean up previously installed nvm installs from ansible-nvm role or other manual process as SELinux will fail to replace the files with symlinks