### PR TITLE
Replace include by include_tasks, fixes deprecation error

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -111,5 +111,5 @@
 
 ### ---- Symlink version-agnostic and version-aware global libs
 - name: Include symlinking routine
-  include: _symlink.yml
+  include_tasks: _symlink.yml
 ### --------------- END ------------- ####


### PR DESCRIPTION
This PR fixes the error:

```
ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.
```